### PR TITLE
Github cli workaround install with dpkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,8 @@ google: ## Install Google SDK (glcoud)
 gh-cli: ## Install Github Cli
 	@echo "Install Github Cli" ;\
 	wget https://github.com/cli/cli/releases/download/v1.1.0/gh_1.1.0_linux_amd64.deb ;\
-	sudo bash -c "apt update -qq && apt install -qq -y ./gh_1.0.0_linux_amd64.deb -f" ;\
-    rm gh_1.0.0_linux_amd64.deb
+	sudo bash -c "dpkg -i ./gh_1.1.0_linux_amd64.deb" ;\
+  rm gh_1.1.0_linux_amd64.deb
 	@echo "Github cli installed!"
 
 pre-commit: ## Install Pre-Commit


### PR DESCRIPTION
GH Cli updated to version 1.1.0 and modified the Makefile to make it work with dpkg.